### PR TITLE
Support AC-style thermostat packets, hide cooling away_mode, update README and bump version

### DIFF
--- a/kocomRS485/README.md
+++ b/kocomRS485/README.md
@@ -156,9 +156,9 @@ THERMOSTAT_DEFAULT_MODE: auto // 난방/냉방 기본 모드 (auto, heat, cool)
 ```
 THERMOSTAT_DEFAULT_MODE가 `auto`이면 5/1 00:00부터 10/1 00:00 전까지는 `cool`, 10/1 00:00부터 다음해 5/1 00:00 전까지는 `heat`로 자동 전환됩니다. `auto` 사용 시 Home Assistant의 난방/냉방/꺼짐 선택지는 현재 계절의 활성 모드와 `off`만 표시되므로, 냉방 기간에는 `cool`/`off`, 난방 기간에는 `heat`/`off`만 노출됩니다. 수동으로 `heat` 또는 `cool`을 고정하면 해당 모드와 `off`만 노출됩니다.
 
-냉방 모드에서는 Home Assistant climate의 `fan_mode`로 에어컨 풍량(`auto`, `low`, `medium`, `high`)을 함께 제어할 수 있습니다. 환풍기 fan 엔티티는 최신 Home Assistant MQTT fan 방식에 맞춰 percentage 기반 풍량(0=꺼짐, 1=low, 2=medium, 3=high)도 지원합니다.
+냉방 모드에서는 Home Assistant climate의 `fan_mode`로 에어컨 풍량(`auto`, `low`, `medium`, `high`)을 함께 제어할 수 있습니다. 냉방용 에어컨 패킷은 난방 외출모드와 별개로 `11 01 ...` 형식을 켜짐, `00 01 ...` 형식을 꺼짐으로 사용하며, Home Assistant 상태 payload와 MQTT discovery에는 `away_mode`를 노출하지 않습니다. 환풍기 fan 엔티티는 최신 Home Assistant MQTT fan 방식에 맞춰 percentage 기반 풍량(0=꺼짐, 1=low, 2=medium, 3=high)도 지원합니다.
 
-MQTT 기기에서는 난방(`heat`) 모드에서만 `away_mode` 토픽(`/homeassistant/climate/<방이름>/away_mode`)을 통해 외출모드를 직접 제어할 수 있습니다. 냉방(`cool`) 모드에서는 코콤 외출모드를 사용하지 않으므로 discovery에 외출모드를 노출하지 않고, `away_mode: on` 상태도 `off`로 보정합니다. 난방 중 `on` 으로 전송하면 월패드가 외출모드(기본 설정 온도 유지)로 동작하고, `off` 로 전환하면 일반 난방 모드로 복귀합니다.
+MQTT 기기에서는 난방(`heat`) 모드에서만 `away_mode` 토픽(`/homeassistant/climate/<방이름>/away_mode`)을 통해 외출모드를 직접 제어할 수 있습니다. 냉방(`cool`) 모드에서는 코콤 외출모드를 사용하지 않으므로 discovery와 상태 payload에 외출모드를 노출하지 않습니다. 난방 중 `on` 으로 전송하면 월패드가 외출모드(기본 설정 온도 유지)로 동작하고, `off` 로 전환하면 일반 난방 모드로 복귀합니다.
 
 ### Option `KOCOM_LIGHT_SIZE` (optional)
 name은 방이름, number는 조명 개수. 본인의 집 수량만큼 추가 가능.

--- a/kocomRS485/config.json
+++ b/kocomRS485/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Kocom Wallpad Controller with RS485 Revised by SIMON",
-  "version": "2.3.260515.5",
+  "version": "2.3.260515.6",
   "slug": "kocom_wallpad",
   "description": "Kocom Wallpad Controller for Homeassistant",
   "arch": [

--- a/kocomRS485/rs485.py
+++ b/kocomRS485/rs485.py
@@ -139,6 +139,18 @@ def apply_pending_thermostat_fan_mode(room_state, payload):
     return payload
 
 
+def build_thermostat_ha_payload(room_state):
+    payload = {
+        'mode': room_state['mode']['set'],
+        'target_temp': room_state['target_temp']['set'],
+        'current_temp': room_state['current_temp']['state'],
+        'fan_mode': room_state['fan_mode']['set']
+    }
+    if thermostat_supports_away_mode():
+        payload['away_mode'] = room_state['away_mode']['set']
+    return payload
+
+
 # 기본 난방/냉방 모드 (애드온 옵션 Advanced.THERMOSTAT_DEFAULT_MODE 또는
 # 환경변수 THERMOSTAT_DEFAULT_MODE 로 변경 가능)
 # auto이면 5/1~10/1 전까지 cool, 10/1~다음해 5/1 전까지 heat로 자동 전환
@@ -773,13 +785,7 @@ class Kocom(rs485):
                     self.wp_list[device][room]['mode']['last'] = 'set'
                     self.wp_list[device][room]['away_mode']['set'] = 'off'
                     self.wp_list[device][room]['away_mode']['last'] = 'set'
-                ha_payload = {
-                    'mode': self.wp_list[device][room]['mode']['set'],
-                    'target_temp': self.wp_list[device][room]['target_temp']['set'],
-                    'current_temp': self.wp_list[device][room]['current_temp']['state'],
-                    'away_mode': self.wp_list[device][room]['away_mode']['set'] if thermostat_supports_away_mode() else 'off',
-                    'fan_mode': self.wp_list[device][room]['fan_mode']['set']
-                }
+                ha_payload = build_thermostat_ha_payload(self.wp_list[device][room])
                 logger.info('[From HA]{}/{}/set = [mode={}, target_temp={}, away_mode={}, fan_mode={}]'.format(
                     device,
                     room,
@@ -1401,18 +1407,20 @@ class Kocom(rs485):
                     away_key = str(away_mode).lower()
                     if str(mode).lower() != mode_key:
                         self.wp_list[device][room]['mode']['set'] = mode_key
-                    if mode_key == 'cool':
+                    if get_thermostat_active_mode() == 'cool' and mode_key in ('cool', 'off'):
                         current_temp = self.wp_list[device][room]['current_temp']['state']
-                        # Cooling-capable Kocom AC packets keep fan speed at value[4:6]
-                        # and target temperature at value[10:12], matching the legacy
-                        # ac_parse() layout: 10 + mode + fan + reserved + current + target.
-                        p_value += '10'
-                        p_value += '00'
-                        p_value += KOCOM_AC_FAN_MODE_REV.get(fan_mode, '02')
-                        p_value += '00'
-                        p_value += '{0:02x}'.format(int(float(current_temp)))
+                        # AC-enabled Kocom thermostat packets report/send power in the
+                        # first byte (11=on, 00=off), cooling mode in the second byte,
+                        # target temperature in byte 3, fan mode in byte 4, and current
+                        # temperature in byte 5.  Do not use the heating away-mode
+                        # prefix (1101) as a special state while the active HVAC mode is
+                        # cool; on the AC packet family that byte pattern means cool on.
+                        p_value += '11' if mode_key == 'cool' else '00'
+                        p_value += '01'
                         p_value += '{0:02x}'.format(int(float(target_temp)))
-                        p_value += '0000'
+                        p_value += KOCOM_THERMOSTAT_FAN_MODE_REV.get(fan_mode, '00')
+                        p_value += '{0:02x}'.format(int(float(current_temp)))
+                        p_value += '000000'
                     else:
                         if mode_key == 'off':
                             mode_prefix = THERMOSTAT_OFF_PREFIX
@@ -1464,19 +1472,34 @@ class Kocom(rs485):
 
     def parse_thermostat(self, value='0000000000000000', init_temp=False):
         thermo = {}
-        if get_thermostat_active_mode() == 'cool' and value[:2] == '10':
-            ac_mode = KOCOM_AC_MODE.get(value[2:4])
-            thermo['current_temp'] = int(value[8:10], 16)
-            thermo['away_mode'] = 'off'
-            thermo['mode'] = ac_mode if ac_mode == 'cool' else get_thermostat_active_mode()
-            thermo['fan_mode'] = KOCOM_AC_FAN_MODE.get(value[4:6], 'auto')
-            try:
-                target_temp = int(value[10:12], 16)
-            except ValueError:
-                target_temp = 0
+        if get_thermostat_active_mode() == 'cool':
             fallback_temp = int(init_temp) if init_temp else INIT_TEMP
-            thermo['target_temp'] = fallback_temp if target_temp == 0 else target_temp
-            return thermo
+            # Current Kocom AC packets use the same 8-byte thermostat value,
+            # but encode power as 11/00 and AC mode as 01.  Example from the
+            # wallpad: 110117001b000000 = cool on, target 23, current 27;
+            # 000117001b000000 = off with the same set/current temperatures.
+            if value[:2] in ('11', '00') and value[2:4] == '01':
+                thermo['current_temp'] = int(value[8:10], 16)
+                thermo['mode'] = 'cool' if value[:2] == '11' else 'off'
+                thermo['fan_mode'] = KOCOM_THERMOSTAT_FAN_MODE.get(value[6:8], 'auto')
+                try:
+                    target_temp = int(value[4:6], 16)
+                except ValueError:
+                    target_temp = 0
+                thermo['target_temp'] = fallback_temp if target_temp == 0 else target_temp
+                return thermo
+
+            if value[:2] == '10':
+                ac_mode = KOCOM_AC_MODE.get(value[2:4])
+                thermo['current_temp'] = int(value[8:10], 16)
+                thermo['mode'] = ac_mode if ac_mode == 'cool' else get_thermostat_active_mode()
+                thermo['fan_mode'] = KOCOM_AC_FAN_MODE.get(value[4:6], 'auto')
+                try:
+                    target_temp = int(value[10:12], 16)
+                except ValueError:
+                    target_temp = 0
+                thermo['target_temp'] = fallback_temp if target_temp == 0 else target_temp
+                return thermo
 
         mode_prefix = value[:4]
         mode_code = THERMOSTAT_PREFIX_TO_MODE.get(mode_prefix)


### PR DESCRIPTION
### Motivation
- Clarify and correctly handle modern Kocom AC-style thermostat packets that encode power and AC mode differently from legacy heating packets. 
- Prevent exposing or using the Kocom "away_mode" when the active HVAC season/mode is cooling. 
- Document the behavior for cooling packets and Home Assistant discovery/payload expectations in the README and bump the addon version.

### Description
- Add `build_thermostat_ha_payload()` to centralize Home Assistant thermostat payload creation and to conditionally include `away_mode` only when supported. 
- Replace inline HA payload construction with `build_thermostat_ha_payload()` when handling incoming HA set commands. 
- Change packet generation for `DEVICE_THERMOSTAT` to emit AC-style packets for cooling with the layout: power (`11`/`00`), AC mode (`01`), target temp, fan mode, current temp, and padding, and avoid treating cooling packets as heating away-mode. 
- Extend `parse_thermostat()` to recognize both the new AC packet family (`11/00` + `01`) and legacy `10` AC packets, correctly parsing `mode`, `target_temp`, `current_temp`, and `fan_mode`. 
- Update `README.md` to explain AC packet format and that `away_mode` is not exposed in discovery or state payloads while in cooling mode, and clarify fan and percentage behavior. 
- Bump `config.json` version from `2.3.260515.5` to `2.3.260515.6`.

### Testing
- Ran unit tests covering thermostat parsing and packet construction, and they passed. 
- Performed MQTT discovery and publish smoke tests for thermostat/fan payloads and they passed. 
- Ran static checks/linting on the modified modules and no new issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a073fcad0548330bce71945a1b2a4cc)