### PR TITLE
Fix thermostat fan mode codes and cooling packet format; update README and bump version

### DIFF
--- a/kocomRS485/README.md
+++ b/kocomRS485/README.md
@@ -156,7 +156,7 @@ THERMOSTAT_DEFAULT_MODE: auto // 난방/냉방 기본 모드 (auto, heat, cool)
 ```
 THERMOSTAT_DEFAULT_MODE가 `auto`이면 5/1 00:00부터 10/1 00:00 전까지는 `cool`, 10/1 00:00부터 다음해 5/1 00:00 전까지는 `heat`로 자동 전환됩니다. `auto` 사용 시 Home Assistant의 난방/냉방/꺼짐 선택지는 현재 계절의 활성 모드와 `off`만 표시되므로, 냉방 기간에는 `cool`/`off`, 난방 기간에는 `heat`/`off`만 노출됩니다. 수동으로 `heat` 또는 `cool`을 고정하면 해당 모드와 `off`만 노출됩니다.
 
-냉방 모드에서는 Home Assistant climate의 `fan_mode`로 에어컨 풍량(`auto`, `low`, `medium`, `high`)을 함께 제어할 수 있습니다. 냉방용 에어컨 패킷은 난방 외출모드와 별개로 `11 01 ...` 형식을 켜짐, `00 01 ...` 형식을 꺼짐으로 사용하며, Home Assistant 상태 payload와 MQTT discovery에는 `away_mode`를 노출하지 않습니다. 환풍기 fan 엔티티는 최신 Home Assistant MQTT fan 방식에 맞춰 percentage 기반 풍량(0=꺼짐, 1=low, 2=medium, 3=high)도 지원합니다.
+냉방 모드에서는 Home Assistant climate의 `fan_mode`로 에어컨 풍량(`LOW`, `MEDIUM`, `HIGH`)을 함께 제어할 수 있습니다. 냉방용 에어컨 패킷은 난방 외출모드와 별개로 켜짐/풍량을 `11 <fan> ...` 형식으로 전송하며, 디버그에서 확인된 것처럼 `LOW=00`, `MEDIUM=01`, `HIGH=02` 코드를 사용합니다. Home Assistant 상태 payload와 MQTT discovery에는 냉방 중 `away_mode`를 노출하지 않습니다. 환풍기 fan 엔티티는 최신 Home Assistant MQTT fan 방식에 맞춰 percentage 기반 풍량(0=꺼짐, 1=low, 2=medium, 3=high)도 지원합니다.
 
 MQTT 기기에서는 난방(`heat`) 모드에서만 `away_mode` 토픽(`/homeassistant/climate/<방이름>/away_mode`)을 통해 외출모드를 직접 제어할 수 있습니다. 냉방(`cool`) 모드에서는 코콤 외출모드를 사용하지 않으므로 discovery와 상태 payload에 외출모드를 노출하지 않습니다. 난방 중 `on` 으로 전송하면 월패드가 외출모드(기본 설정 온도 유지)로 동작하고, `off` 로 전환하면 일반 난방 모드로 복귀합니다.
 

--- a/kocomRS485/config.json
+++ b/kocomRS485/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Kocom Wallpad Controller with RS485 Revised by SIMON",
-  "version": "2.3.260516.2",
+  "version": "2.3.260516.3",
   "slug": "kocom_wallpad",
   "description": "Kocom Wallpad Controller for Homeassistant",
   "arch": [

--- a/kocomRS485/rs485.py
+++ b/kocomRS485/rs485.py
@@ -222,7 +222,7 @@ KOCOM_COMMAND               = {'3a': '조회', '00': '상태', '01': 'on', '02':
 KOCOM_TYPE                  = {'30b': 'send', '30d': 'ack'}
 KOCOM_FAN_SPEED             = {'4': 'low', '8': 'medium', 'c': 'high', '0': 'off'}
 KOCOM_THERMOSTAT_HEAT_FAN_MODE = {'00': 'auto', '04': 'low', '08': 'medium', '0c': 'high'}
-KOCOM_THERMOSTAT_FAN_MODE   = {'01': 'LOW', '02': 'MEDIUM', '03': 'HIGH'}
+KOCOM_THERMOSTAT_FAN_MODE   = {'00': 'LOW', '01': 'MEDIUM', '02': 'HIGH'}
 THERMOSTAT_FAN_MODE_MAX_PENDING_COUNT = 4
 FAN_PERCENTAGE_TO_SPEED     = {'0': 'off', '1': 'low', '2': 'medium', '3': 'high'}
 FAN_SPEED_TO_PERCENTAGE     = {'off': 0, 'low': 1, 'medium': 2, 'high': 3}
@@ -265,6 +265,13 @@ def normalize_thermostat_fan_mode(fan_mode, mode=None):
 
 def parse_thermostat_fan_mode(code, mode=None):
     return get_thermostat_fan_mode_map(mode).get(code, get_default_thermostat_fan_mode(mode))
+
+
+def get_thermostat_fan_mode_code(value, mode=None):
+    if mode == 'cool':
+        # 에어컨 상태 패킷은 두 번째 바이트(11 xx ...)에 풍량을 싣습니다.
+        return value[2:4]
+    return value[6:8]
 
 
 def encode_thermostat_fan_mode(fan_mode, mode=None):
@@ -769,9 +776,6 @@ class Kocom(rs485):
                     if self.wp_list[device][room]['mode']['set'] == 'off':
                         self.wp_list[device][room]['mode']['set'] = get_thermostat_active_mode()
                         self.wp_list[device][room]['mode']['last'] = 'set'
-                    if not thermostat_supports_away_mode():
-                        self.wp_list[device][room]['away_mode']['set'] = 'off'
-                        self.wp_list[device][room]['away_mode']['last'] = 'set'
                 else:
                     self.wp_list[device][room]['target_temp']['set'] = int(float(payload))
                     self.wp_list[device][room]['target_temp']['last'] = 'set'
@@ -1413,10 +1417,17 @@ class Kocom(rs485):
                         mode_prefix = THERMOSTAT_AWAY_PREFIX
                     else:
                         mode_prefix = THERMOSTAT_ACTIVE_PREFIX
-                    p_value += mode_prefix
-                    p_value += '{0:02x}'.format(int(float(target_temp)))
-                    p_value += encode_thermostat_fan_mode(fan_mode, mode_key) or encode_thermostat_fan_mode(get_default_thermostat_fan_mode(mode_key), mode_key)
-                    p_value += '00000000'
+                    fan_mode_code = encode_thermostat_fan_mode(fan_mode, mode_key) or encode_thermostat_fan_mode(get_default_thermostat_fan_mode(mode_key), mode_key)
+                    target_temp_code = '{0:02x}'.format(int(float(target_temp)))
+                    if mode_key == 'cool' and mode_key != 'off':
+                        # 에어컨은 난방과 달리 풍량이 목표온도 뒤가 아니라
+                        # ON 바이트(11) 바로 뒤에 들어갑니다: 11 <fan> <temp> 00 ...
+                        p_value += '11' + fan_mode_code + target_temp_code + '0000000000'
+                    else:
+                        p_value += mode_prefix
+                        p_value += target_temp_code
+                        p_value += fan_mode_code
+                        p_value += '00000000'
                 except:
                     logger.debug('[Make Packet] Error on DEVICE_THERMOSTAT')
             elif device == DEVICE_FAN:
@@ -1470,7 +1481,7 @@ class Kocom(rs485):
         thermo['current_temp'] = int(value[8:10], 16)
         thermo['away_mode'] = away_mode
         thermo['mode'] = hvac_mode if hvac_mode != 'off' else 'off'
-        thermo['fan_mode'] = parse_thermostat_fan_mode(value[6:8], thermo['mode'])
+        thermo['fan_mode'] = parse_thermostat_fan_mode(get_thermostat_fan_mode_code(value, thermo['mode']), thermo['mode'])
 
         try:
             target_temp = int(value[4:6], 16)


### PR DESCRIPTION
### Motivation

- Correct handling of thermostat (cooling) fan codes and packet layout so fan speed is parsed and encoded from the correct byte positions for AC mode. 

### Description

- Update fan code mapping `KOCOM_THERMOSTAT_FAN_MODE` to use `{'00':'LOW','01':'MEDIUM','02':'HIGH'}` to match observed device codes. 
- Add `get_thermostat_fan_mode_code` to extract fan speed bytes from different offsets depending on HVAC mode and use it from `parse_thermostat`. 
- Change thermostat packet composition so cooling packets send `11 <fan> <temp> ...` (fan immediately after the `11` ON byte) while other modes keep the existing `mode_prefix + temp + fan + ...` layout. 
- Remove the code that forced `away_mode` off when receiving a `fan_mode` set, and bump the add-on `version` in `config.json`; update `README.md` to document the cooling fan codes and packet format. 

### Testing

- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a074960b8988330bd7c9b6fdbe019bb)